### PR TITLE
add corporate-specific pricing module with secure endpoints and service layer

### DIFF
--- a/product-api/src/main/java/com/mankind/api/product/dto/corporate/CorporatePriceDTO.java
+++ b/product-api/src/main/java/com/mankind/api/product/dto/corporate/CorporatePriceDTO.java
@@ -1,0 +1,36 @@
+package com.mankind.api.product.dto.corporate;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+@Schema(description = "DTO for corporate price operations (create/update)")
+public class CorporatePriceDTO {
+    
+    @NotNull(message = "Product ID is required")
+    @Schema(description = "ID of the product", example = "1")
+    private Long productId;
+    
+    @NotNull(message = "Price in cents is required")
+    @Min(value = 0, message = "Price must be greater than or equal to 0")
+    @Schema(description = "Price in cents", example = "1999")
+    private Long priceInCents;
+    
+    @NotBlank(message = "Currency is required")
+    @Size(min = 3, max = 3, message = "Currency must be a 3-letter code")
+    @Schema(description = "Currency code (ISO 4217)", example = "USD")
+    private String currency;
+    
+    @NotNull(message = "Effective from date is required")
+    @Schema(description = "Date from which the price is effective", example = "2023-01-01T00:00:00")
+    private LocalDateTime effectiveFrom;
+    
+    @Schema(description = "Date until which the price is effective (null means indefinite)", example = "2023-12-31T23:59:59")
+    private LocalDateTime effectiveTo;
+}

--- a/product-api/src/main/java/com/mankind/api/product/dto/corporate/CorporatePriceResponseDTO.java
+++ b/product-api/src/main/java/com/mankind/api/product/dto/corporate/CorporatePriceResponseDTO.java
@@ -1,0 +1,45 @@
+package com.mankind.api.product.dto.corporate;
+
+import com.mankind.api.product.dto.product.ProductResponseDTO;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+@Schema(description = "DTO for corporate price responses")
+public class CorporatePriceResponseDTO {
+    
+    @Schema(description = "ID of the corporate price", example = "1")
+    private Long id;
+    
+    @Schema(description = "ID of the corporate", example = "1")
+    private Long corporateId;
+    
+    @Schema(description = "ID of the product", example = "1")
+    private Long productId;
+    
+    @Schema(description = "Product details")
+    private ProductResponseDTO product;
+    
+    @Schema(description = "Price in cents", example = "1999")
+    private Long priceInCents;
+    
+    @Schema(description = "Currency code (ISO 4217)", example = "USD")
+    private String currency;
+    
+    @Schema(description = "Date from which the price is effective", example = "2023-01-01T00:00:00")
+    private LocalDateTime effectiveFrom;
+    
+    @Schema(description = "Date until which the price is effective (null means indefinite)", example = "2023-12-31T23:59:59")
+    private LocalDateTime effectiveTo;
+    
+    @Schema(description = "User who last updated the price", example = "john.doe@example.com")
+    private String updatedBy;
+    
+    @Schema(description = "Date when the price was last updated", example = "2023-01-01T12:34:56")
+    private LocalDateTime updatedAt;
+    
+    @Schema(description = "Date when the price was created", example = "2023-01-01T12:34:56")
+    private LocalDateTime createdAt;
+}

--- a/product-service/src/main/java/com/mankind/matrix_product_service/controller/CorporatePriceController.java
+++ b/product-service/src/main/java/com/mankind/matrix_product_service/controller/CorporatePriceController.java
@@ -1,0 +1,128 @@
+package com.mankind.matrix_product_service.controller;
+
+import com.mankind.api.product.dto.corporate.CorporatePriceDTO;
+import com.mankind.api.product.dto.corporate.CorporatePriceResponseDTO;
+import com.mankind.matrix_product_service.service.CorporatePriceService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/corporates")
+@RequiredArgsConstructor
+@Slf4j
+@Tag(name = "Corporate Pricing", description = "APIs for managing corporate-specific product prices")
+@SecurityRequirement(name = "bearerAuth")
+public class CorporatePriceController {
+    private final CorporatePriceService corporatePriceService;
+
+    @Operation(summary = "Update a corporate price", description = "Updates or creates a price for a specific product for a corporate")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "Price successfully updated",
+                    content = @Content(schema = @Schema(implementation = CorporatePriceResponseDTO.class))),
+        @ApiResponse(responseCode = "400", description = "Invalid input"),
+        @ApiResponse(responseCode = "403", description = "Forbidden - User not authorized for this corporate"),
+        @ApiResponse(responseCode = "404", description = "Product not found"),
+        @ApiResponse(responseCode = "500", description = "Internal server error")
+    })
+    @PutMapping("/{corpId}/prices/{productId}")
+    public ResponseEntity<CorporatePriceResponseDTO> updatePrice(
+            @Parameter(description = "Corporate ID", required = true) @PathVariable Long corpId,
+            @Parameter(description = "Product ID", required = true) @PathVariable Long productId,
+            @Parameter(description = "Price details", required = true) @Valid @RequestBody CorporatePriceDTO priceDTO) {
+        
+        // Verify the user has access to this corporate
+        verifyUserHasAccessToCorporate(corpId);
+        
+        // Get the username from the JWT token
+        String username = getCurrentUsername();
+        
+        return ResponseEntity.ok(corporatePriceService.updatePrice(corpId, productId, priceDTO, username));
+    }
+
+    @Operation(summary = "Get a corporate price", description = "Retrieves the current price for a specific product for a corporate")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "Price successfully retrieved",
+                    content = @Content(schema = @Schema(implementation = CorporatePriceResponseDTO.class))),
+        @ApiResponse(responseCode = "403", description = "Forbidden - User not authorized for this corporate"),
+        @ApiResponse(responseCode = "404", description = "Price not found"),
+        @ApiResponse(responseCode = "500", description = "Internal server error")
+    })
+    @GetMapping("/{corpId}/prices/{productId}")
+    public ResponseEntity<CorporatePriceResponseDTO> getPrice(
+            @Parameter(description = "Corporate ID", required = true) @PathVariable Long corpId,
+            @Parameter(description = "Product ID", required = true) @PathVariable Long productId) {
+        
+        // Verify the user has access to this corporate
+        verifyUserHasAccessToCorporate(corpId);
+        
+        return ResponseEntity.ok(corporatePriceService.getPriceByCorpIdAndProductId(corpId, productId));
+    }
+
+    @Operation(summary = "Get all corporate prices", description = "Retrieves all current prices for a corporate")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "Prices successfully retrieved",
+                    content = @Content(schema = @Schema(implementation = CorporatePriceResponseDTO.class))),
+        @ApiResponse(responseCode = "403", description = "Forbidden - User not authorized for this corporate"),
+        @ApiResponse(responseCode = "500", description = "Internal server error")
+    })
+    @GetMapping("/{corpId}/prices")
+    public ResponseEntity<List<CorporatePriceResponseDTO>> getAllPrices(
+            @Parameter(description = "Corporate ID", required = true) @PathVariable Long corpId) {
+        
+        // Verify the user has access to this corporate
+        verifyUserHasAccessToCorporate(corpId);
+        
+        return ResponseEntity.ok(corporatePriceService.getAllPricesByCorpId(corpId));
+    }
+
+    /**
+     * Verify that the current user has access to the specified corporate
+     * 
+     * @param corpId the corporate ID to check
+     * @throws org.springframework.security.access.AccessDeniedException if the user doesn't have access
+     */
+    private void verifyUserHasAccessToCorporate(Long corpId) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication != null && authentication.getPrincipal() instanceof Jwt) {
+            Jwt jwt = (Jwt) authentication.getPrincipal();
+            
+            // Get the corporate IDs from the JWT claims
+            List<String> corporateIds = jwt.getClaimAsStringList("corporate_ids");
+            if (corporateIds == null || !corporateIds.contains(corpId.toString())) {
+                throw new org.springframework.security.access.AccessDeniedException(
+                        "User not authorized to access corporate ID: " + corpId);
+            }
+        } else {
+            throw new org.springframework.security.access.AccessDeniedException("Authentication required");
+        }
+    }
+
+    /**
+     * Get the username from the current authentication
+     * 
+     * @return the username
+     */
+    private String getCurrentUsername() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication != null) {
+            return authentication.getName();
+        }
+        return "system";
+    }
+}

--- a/product-service/src/main/java/com/mankind/matrix_product_service/mapper/CorporatePriceMapper.java
+++ b/product-service/src/main/java/com/mankind/matrix_product_service/mapper/CorporatePriceMapper.java
@@ -1,0 +1,60 @@
+package com.mankind.matrix_product_service.mapper;
+
+import com.mankind.api.product.dto.corporate.CorporatePriceDTO;
+import com.mankind.api.product.dto.corporate.CorporatePriceResponseDTO;
+import com.mankind.matrix_product_service.model.CorporatePrice;
+import org.mapstruct.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE, uses = {ProductMapper.class})
+public interface CorporatePriceMapper {
+    
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "corporateId", ignore = true) // This will be set from the path variable
+    @Mapping(target = "product", ignore = true)
+    @Mapping(target = "updatedBy", ignore = true) // This will be set from the authenticated user
+    @Mapping(target = "updatedAt", ignore = true) // This will be set automatically
+    @Mapping(target = "createdAt", ignore = true) // This will be set automatically
+    CorporatePrice toEntity(CorporatePriceDTO dto);
+    
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "corporateId", ignore = true) // This will be preserved
+    @Mapping(target = "productId", ignore = true) // This will be preserved
+    @Mapping(target = "product", ignore = true)
+    @Mapping(target = "updatedBy", ignore = true) // This will be set from the authenticated user
+    @Mapping(target = "updatedAt", ignore = true) // This will be set automatically
+    @Mapping(target = "createdAt", ignore = true) // This will be preserved
+    void updateEntityFromDTO(CorporatePriceDTO dto, @MappingTarget CorporatePrice entity);
+    
+    @Mapping(target = "product", source = "product", qualifiedByName = "toProductResponseDTO")
+    CorporatePriceResponseDTO toResponseDTO(CorporatePrice entity);
+    
+    List<CorporatePriceResponseDTO> toResponseDTOList(List<CorporatePrice> entities);
+    
+    @Named("toProductResponseDTO")
+    default com.mankind.api.product.dto.product.ProductResponseDTO toProductResponseDTO(com.mankind.matrix_product_service.model.Product product) {
+        if (product == null) {
+            return null;
+        }
+        return ((ProductMapper) this).toResponseDTO(product);
+    }
+    
+    default CorporatePrice createWithCorporateId(CorporatePriceDTO dto, Long corporateId, String updatedBy) {
+        if (dto == null) {
+            return null;
+        }
+        
+        CorporatePrice entity = toEntity(dto);
+        entity.setCorporateId(corporateId);
+        entity.setUpdatedBy(updatedBy);
+        
+        // Set default values if not provided
+        if (entity.getEffectiveFrom() == null) {
+            entity.setEffectiveFrom(LocalDateTime.now());
+        }
+        
+        return entity;
+    }
+}

--- a/product-service/src/main/java/com/mankind/matrix_product_service/model/CorporatePrice.java
+++ b/product-service/src/main/java/com/mankind/matrix_product_service/model/CorporatePrice.java
@@ -1,0 +1,57 @@
+package com.mankind.matrix_product_service.model;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "corporate_prices", uniqueConstraints = {
+    @UniqueConstraint(columnNames = {"corporate_id", "product_id", "effective_from"})
+})
+@Getter
+@Setter
+@EntityListeners(AuditingEntityListener.class)
+public class CorporatePrice {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "corporate_id", nullable = false)
+    private Long corporateId;
+
+    @Column(name = "product_id", nullable = false)
+    private Long productId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_id", insertable = false, updatable = false)
+    private Product product;
+
+    @Column(name = "price_in_cents", nullable = false)
+    private Long priceInCents;
+
+    @Column(length = 3, nullable = false)
+    private String currency;
+
+    @Column(name = "effective_from", nullable = false)
+    private LocalDateTime effectiveFrom;
+
+    @Column(name = "effective_to")
+    private LocalDateTime effectiveTo;
+
+    @Column(name = "updated_by", nullable = false)
+    private String updatedBy;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+}

--- a/product-service/src/main/java/com/mankind/matrix_product_service/repository/CorporatePriceRepository.java
+++ b/product-service/src/main/java/com/mankind/matrix_product_service/repository/CorporatePriceRepository.java
@@ -1,0 +1,62 @@
+package com.mankind.matrix_product_service.repository;
+
+import com.mankind.matrix_product_service.model.CorporatePrice;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface CorporatePriceRepository extends JpaRepository<CorporatePrice, Long> {
+    
+    /**
+     * Find the current valid price for a specific corporate and product
+     * @param corporateId the corporate ID
+     * @param productId the product ID
+     * @param currentDate the current date to check validity
+     * @return the valid corporate price
+     */
+    @Query("SELECT cp FROM CorporatePrice cp WHERE cp.corporateId = :corporateId " +
+           "AND cp.productId = :productId " +
+           "AND cp.effectiveFrom <= :currentDate " +
+           "AND (cp.effectiveTo IS NULL OR cp.effectiveTo > :currentDate) " +
+           "ORDER BY cp.effectiveFrom DESC")
+    Optional<CorporatePrice> findCurrentPrice(
+            @Param("corporateId") Long corporateId,
+            @Param("productId") Long productId,
+            @Param("currentDate") LocalDateTime currentDate);
+    
+    /**
+     * Find all current valid prices for a specific corporate
+     * @param corporateId the corporate ID
+     * @param currentDate the current date to check validity
+     * @return list of valid corporate prices
+     */
+    @Query("SELECT cp FROM CorporatePrice cp WHERE cp.corporateId = :corporateId " +
+           "AND cp.effectiveFrom <= :currentDate " +
+           "AND (cp.effectiveTo IS NULL OR cp.effectiveTo > :currentDate) " +
+           "ORDER BY cp.productId, cp.effectiveFrom DESC")
+    List<CorporatePrice> findAllCurrentPricesByCorporateId(
+            @Param("corporateId") Long corporateId,
+            @Param("currentDate") LocalDateTime currentDate);
+    
+    /**
+     * Find all prices (including historical) for a specific corporate and product
+     * @param corporateId the corporate ID
+     * @param productId the product ID
+     * @return list of all corporate prices for the product
+     */
+    List<CorporatePrice> findByCorporateIdAndProductIdOrderByEffectiveFromDesc(
+            Long corporateId, Long productId);
+    
+    /**
+     * Find all prices (including historical) for a specific corporate
+     * @param corporateId the corporate ID
+     * @return list of all corporate prices
+     */
+    List<CorporatePrice> findByCorporateIdOrderByProductIdAscEffectiveFromDesc(Long corporateId);
+}

--- a/product-service/src/main/java/com/mankind/matrix_product_service/service/CorporatePriceService.java
+++ b/product-service/src/main/java/com/mankind/matrix_product_service/service/CorporatePriceService.java
@@ -1,0 +1,125 @@
+package com.mankind.matrix_product_service.service;
+
+import com.mankind.api.product.dto.corporate.CorporatePriceDTO;
+import com.mankind.api.product.dto.corporate.CorporatePriceResponseDTO;
+import com.mankind.matrix_product_service.exception.ResourceNotFoundException;
+import com.mankind.matrix_product_service.mapper.CorporatePriceMapper;
+import com.mankind.matrix_product_service.model.CorporatePrice;
+import com.mankind.matrix_product_service.model.Product;
+import com.mankind.matrix_product_service.repository.CorporatePriceRepository;
+import com.mankind.matrix_product_service.repository.ProductRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class CorporatePriceService {
+    private final CorporatePriceRepository corporatePriceRepository;
+    private final ProductRepository productRepository;
+    private final CorporatePriceMapper corporatePriceMapper;
+
+    /**
+     * Update or create a corporate price for a specific product
+     * 
+     * @param corporateId the corporate ID
+     * @param productId the product ID
+     * @param priceDTO the price data
+     * @param username the username of the authenticated user
+     * @return the updated or created corporate price
+     */
+    @Transactional
+    public CorporatePriceResponseDTO updatePrice(Long corporateId, Long productId, CorporatePriceDTO priceDTO, String username) {
+        log.info("Updating price for corporate ID: {}, product ID: {}", corporateId, productId);
+        
+        // Validate product exists
+        Product product = productRepository.findById(productId)
+                .orElseThrow(() -> new ResourceNotFoundException("Product not found with ID: " + productId));
+        
+        // Check if there's an existing current price
+        LocalDateTime now = LocalDateTime.now();
+        CorporatePrice existingPrice = corporatePriceRepository.findCurrentPrice(corporateId, productId, now)
+                .orElse(null);
+        
+        CorporatePrice corporatePrice;
+        if (existingPrice != null) {
+            // If there's an existing price, update it or expire it and create a new one
+            if (existingPrice.getEffectiveTo() == null || existingPrice.getEffectiveTo().isAfter(now)) {
+                // If the existing price is still effective, expire it
+                existingPrice.setEffectiveTo(now);
+                corporatePriceRepository.save(existingPrice);
+            }
+            
+            // Create a new price record
+            corporatePrice = corporatePriceMapper.createWithCorporateId(priceDTO, corporateId, username);
+            corporatePrice.setProductId(productId);
+        } else {
+            // If there's no existing price, create a new one
+            corporatePrice = corporatePriceMapper.createWithCorporateId(priceDTO, corporateId, username);
+            corporatePrice.setProductId(productId);
+        }
+        
+        // Save the new price
+        CorporatePrice savedPrice = corporatePriceRepository.save(corporatePrice);
+        log.info("Price updated successfully for corporate ID: {}, product ID: {}", corporateId, productId);
+        
+        return corporatePriceMapper.toResponseDTO(savedPrice);
+    }
+    
+    /**
+     * Get the current price for a specific corporate and product
+     * 
+     * @param corporateId the corporate ID
+     * @param productId the product ID
+     * @return the current price
+     */
+    @Transactional(readOnly = true)
+    public CorporatePriceResponseDTO getPriceByCorpIdAndProductId(Long corporateId, Long productId) {
+        log.info("Getting price for corporate ID: {}, product ID: {}", corporateId, productId);
+        
+        LocalDateTime now = LocalDateTime.now();
+        CorporatePrice price = corporatePriceRepository.findCurrentPrice(corporateId, productId, now)
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        "No current price found for corporate ID: " + corporateId + " and product ID: " + productId));
+        
+        return corporatePriceMapper.toResponseDTO(price);
+    }
+    
+    /**
+     * Get all current prices for a specific corporate
+     * 
+     * @param corporateId the corporate ID
+     * @return list of all current prices
+     */
+    @Transactional(readOnly = true)
+    public List<CorporatePriceResponseDTO> getAllPricesByCorpId(Long corporateId) {
+        log.info("Getting all prices for corporate ID: {}", corporateId);
+        
+        LocalDateTime now = LocalDateTime.now();
+        List<CorporatePrice> prices = corporatePriceRepository.findAllCurrentPricesByCorporateId(corporateId, now);
+        
+        return corporatePriceMapper.toResponseDTOList(prices);
+    }
+    
+    /**
+     * Get all prices (including historical) for a specific corporate and product
+     * 
+     * @param corporateId the corporate ID
+     * @param productId the product ID
+     * @return list of all prices
+     */
+    @Transactional(readOnly = true)
+    public List<CorporatePriceResponseDTO> getAllPriceHistoryByCorpIdAndProductId(Long corporateId, Long productId) {
+        log.info("Getting price history for corporate ID: {}, product ID: {}", corporateId, productId);
+        
+        List<CorporatePrice> prices = corporatePriceRepository
+                .findByCorporateIdAndProductIdOrderByEffectiveFromDesc(corporateId, productId);
+        
+        return corporatePriceMapper.toResponseDTOList(prices);
+    }
+}


### PR DESCRIPTION
This PR adds a secure pricing module that allows corporate users to view and update product prices scoped to their organization.

**Key Changes:**

Created corporate_prices table with unique constraints
Added CorporatePrice entity and JPA repository
Built CorporatePriceService with update and retrieval logic
Implemented CorporatePriceController with the following endpoints:

PUT /api/v1/corporates/{corpId}/prices/{productId}
GET /api/v1/corporates/{corpId}/prices/{productId}
GET /api/v1/corporates/{corpId}/prices

Enforced tenant-level isolation using JWT-based corpId validation
Swagger annotations added for API documentation