### PR TITLE
to get dashboard details for suppliers

### DIFF
--- a/product-api/src/main/java/com/mankind/api/product/dto/supplier/SupplierDashboardDTO.java
+++ b/product-api/src/main/java/com/mankind/api/product/dto/supplier/SupplierDashboardDTO.java
@@ -1,0 +1,37 @@
+package com.mankind.api.product.dto.supplier;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "Dashboard metrics for a supplier")
+public class SupplierDashboardDTO {
+    @Schema(description = "Supplier ID", example = "1")
+    private Long supplierId;
+
+    @Schema(description = "Supplier name", example = "Tech Supplies Inc.")
+    private String supplierName;
+
+    @Schema(description = "Total number of products linked to this supplier", example = "42")
+    private long totalProducts;
+
+    @Schema(description = "Number of active products", example = "38")
+    private long activeProducts;
+
+    @Schema(description = "Number of inactive products", example = "4")
+    private long inactiveProducts;
+
+    @Schema(description = "When the supplier record was created")
+    private LocalDateTime createdAt;
+
+    @Schema(description = "When the supplier record was last updated")
+    private LocalDateTime updatedAt;
+}

--- a/product-service/src/main/java/com/mankind/matrix_product_service/controller/SupplierController.java
+++ b/product-service/src/main/java/com/mankind/matrix_product_service/controller/SupplierController.java
@@ -2,6 +2,7 @@ package com.mankind.matrix_product_service.controller;
 
 import com.mankind.api.product.dto.supplier.SupplierDTO;
 import com.mankind.api.product.dto.supplier.SupplierResponseDTO;
+import com.mankind.api.product.dto.supplier.SupplierDashboardDTO;
 import com.mankind.matrix_product_service.service.SupplierService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -101,5 +102,19 @@ public class SupplierController {
             @PathVariable Long id) {
         supplierService.deleteSupplier(id);
         return ResponseEntity.noContent().build();
+    }
+
+    @Operation(summary = "Get supplier dashboard", description = "Retrieves dashboard metrics for a supplier including product counts")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "Successfully retrieved dashboard",
+                content = @Content(schema = @Schema(implementation = SupplierDashboardDTO.class))),
+        @ApiResponse(responseCode = "404", description = "Supplier not found"),
+        @ApiResponse(responseCode = "500", description = "Internal server error")
+    })
+    @GetMapping("/{id}/dashboard")
+    public ResponseEntity<SupplierDashboardDTO> getSupplierDashboard(
+            @Parameter(description = "ID of the supplier to retrieve dashboard for", required = true)
+            @PathVariable Long id) {
+        return ResponseEntity.ok(supplierService.getSupplierDashboard(id));
     }
 }

--- a/product-service/src/main/java/com/mankind/matrix_product_service/repository/ProductRepository.java
+++ b/product-service/src/main/java/com/mankind/matrix_product_service/repository/ProductRepository.java
@@ -17,5 +17,10 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
     boolean existsByNameAndCategoryId(String name, Long categoryId);
     boolean existsByNameAndCategoryIdAndIdNot(String name, Long categoryId, Long id);
     Page<Product> findByIsFeaturedTrueAndIsActiveTrue(Pageable pageable);
+
+    // Dashboard metrics for suppliers
+    long countBySuppliers_Id(Long supplierId);
+    long countBySuppliers_IdAndIsActiveTrue(Long supplierId);
+    long countBySuppliers_IdAndIsActiveFalse(Long supplierId);
 }
 


### PR DESCRIPTION
This pull request introduces the new supplier dashboard API (GET /suppliers/{id}/dashboard). It provides supplier details along with product metrics, including total, active, and inactive product counts. The response also includes created and updated timestamps to track supplier data changes. Proper status codes have been implemented for successful retrieval (200), supplier not found (404), and internal server errors (500). This feature has been tested through Swagger UI to ensure accurate responses.